### PR TITLE
[HIG-2134] support error boundary style for next.js

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -6,7 +6,13 @@ module.exports = function (api) {
     "@babel/preset-react",
     "@babel/preset-typescript",
   ];
-  const plugins = ['css-modules-transform'];
+  const plugins = [
+    [
+      "css-modules-transform", {
+	      "extractCss": "./dist/highlight.css",
+      }
+    ]
+  ];
 
   return {
     presets,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@highlight-run/react",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "The official Highlight SDK for React",
   "main": "dist/index.js",
   "license": "MIT",


### PR DESCRIPTION
next-js or other frameworks that do not allow dynamic requires should use
```
import '@highlight-run/react/dist/highlight.css'
```
to import the stylesheets.

https://www.loom.com/share/ad9311a5dda745c9a1fbd5514faf31db