### PR TITLE
[HIG-2136] provide a sample buggy button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@highlight-run/react",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "The official Highlight SDK for React",
   "main": "dist/index.js",
   "license": "MIT",

--- a/src/components/SampleBuggyButton/SampleBuggyButton.module.css
+++ b/src/components/SampleBuggyButton/SampleBuggyButton.module.css
@@ -1,0 +1,18 @@
+.button {
+  align-items: center;
+  background: #5629c6;
+  border-radius: 8px;
+  border: 1px solid #bdbdbd;
+  box-shadow: none;
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  font-size: 14px;
+  height: auto;
+  justify-content: center;
+  min-height: 40px;
+  padding-bottom: 8px;
+  padding-top: 8px;
+  padding: 4px 16px;
+  text-shadow: none;
+}

--- a/src/components/SampleBuggyButton/SampleBuggyButton.tsx
+++ b/src/components/SampleBuggyButton/SampleBuggyButton.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import styles from './SampleBuggyButton.module.css'
+
+export const SampleBuggyButton = ({children}: React.PropsWithChildren<{}>) => {
+  const [isError, setError] = React.useState(false);
+  if (isError) {
+    throw new Error('something bad happened - this is a sample test error')
+  }
+  return (
+    <button type="button" className={styles.button} onClick={() => setError(true)}>
+        {children ?? 'Throw an Error'}
+    </button>
+  )
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,2 @@
 export * from "./ErrorBoundary/ErrorBoundary";
+export * from "./SampleBuggyButton/SampleBuggyButton";


### PR DESCRIPTION
Adds a `<SampleBuggyButton/>` button component that
will throw a React error on render when clicked.
This allows easy validation of the `<ErrorBoundary/>` component.