### PR TITLE
Explicity include children in props for React 18

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -10,6 +10,7 @@ export type FallbackRender = (errorData: {
 }) => React.ReactElement;
 
 export type ErrorBoundaryProps = {
+  children?: React.ReactNode | function;
   /** If a Highlight report dialog should be rendered on error */
   showDialog?: boolean;
   /** A custom dialog that you can provide to be shown when the ErrorBoundary is shown. */


### PR DESCRIPTION
I recently updated my personal site to React 18, and I kept getting the following error when building my project:
```
[0] No overload matches this call.
[0]   Overload 1 of 2, '(props: ErrorBoundaryProps | Readonly<ErrorBoundaryProps>): ErrorBoundary', gave the following error.
[0]     Type '{ children: Element; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<ErrorBoundary> & Readonly<ErrorBoundaryProps>'.
[0]   Overload 2 of 2, '(props: ErrorBoundaryProps, context: any): ErrorBoundary', gave the following error.
[0]     Type '{ children: Element; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<ErrorBoundary> & Readonly<ErrorBoundaryProps>'.  TS2769
```

It turns out that React 18 removed implicit children, check out the first breaking change in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210