### PR TITLE
generate highlight.css for backwards compatability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@highlight-run/react",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The official Highlight SDK for React",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,6 +8,21 @@ import { terser } from "rollup-plugin-terser";
 import pkg from "./package.json";
 
 const rollupBuilds = [
+  // the first build is just for exporting highlight.css.
+  {
+    input: "./src/index.tsx",
+    output: { file: pkg.main },
+    external: ["react", "react/jsx-runtime"], // peer dependencies
+    plugins: [
+      postcss({
+        minimize: true,
+        sourceMap: true,
+        extract: "highlight.css",
+      }),
+      esbuild(),
+    ],
+  },
+  // the second build replaces the js file produced by the first build.
   {
     input: "./src/index.tsx",
     output: [


### PR DESCRIPTION
a little janky, but since we can't have [postcss extract and inject styles in one build](https://github.com/egoist/rollup-plugin-postcss/issues/120), split them out to get both.

Testing: `index.js` and `.es.js` files have inlined css. local also nextjs app works with `highlight.css` import.